### PR TITLE
Bugfix: don't show text on all pages

### DIFF
--- a/app/routes/_dashboard.tsx
+++ b/app/routes/_dashboard.tsx
@@ -4,6 +4,7 @@ import {
   Outlet,
   useLoaderData,
   useRouteError,
+  useLocation,
 } from "@remix-run/react";
 import ErrorComponent from "~/components/Error";
 import NavigationCard from "~/components/card/NavigationCard";
@@ -39,31 +40,35 @@ export default function Dashboard() {
 
   return (
     <div className="w-full sm:mt-16">
-      <section className="text-left text-white">
-        <p className="font-serif text-xl">En variants</p>
-        <h2>Læringshub</h2>
-        <p className="mt-8">
-          I Variant er læreglede en av våre{" "}
-          <a
-            aria-label="Variants hovedverdier"
-            href="https://variant.no"
-            className="text-variant-beige"
-          >
-            hovedverdier
-          </a>
-          . Vi digger å lære oss nye ting eller å lære bort det vi kan, og så
-          blir vi jaggu meg så mye bedre på det når vi deler det med hverandre.
-        </p>
-        <p className="py-1">
-          For å gi deg (og oss selv) bedre oversikt over alt faglig innhold som
-          vi poster, har vi samlet hele sulamitten på denne siden. Vi kaller den
-          herved Læringshuben. Sjå dæ rundt og så håper vi du liker det du ser.
-        </p>
-        <p className="py-1">
-          PS: Ikke vær sjenert om du vil slå av en prat med oss, om et tema som
-          engasjerer deg da ❤️
-        </p>
-      </section>
+      {useLocation().pathname === "/" && (
+        <section className="text-left text-white">
+          <p className="font-serif text-xl">En variants</p>
+          <h2>Læringshub</h2>
+          <p className="mt-8">
+            I Variant er læreglede en av våre{" "}
+            <a
+              aria-label="Variants hovedverdier"
+              href="https://variant.no"
+              className="text-variant-beige"
+            >
+              hovedverdier
+            </a>
+            . Vi digger å lære oss nye ting eller å lære bort det vi kan, og så
+            blir vi jaggu meg så mye bedre på det når vi deler det med
+            hverandre.
+          </p>
+          <p className="py-1">
+            For å gi deg (og oss selv) bedre oversikt over alt faglig innhold
+            som vi poster, har vi samlet hele sulamitten på denne siden. Vi
+            kaller den herved Læringshuben. Sjå dæ rundt og så håper vi du liker
+            det du ser.
+          </p>
+          <p className="py-1">
+            PS: Ikke vær sjenert om du vil slå av en prat med oss, om et tema
+            som engasjerer deg da ❤️
+          </p>
+        </section>
+      )}
 
       <section className="mb-12 mt-8 grid grid-cols-1 gap-5 xs:grid-cols-2 sm:grid-cols-3 md:grid-cols-5">
         <NavLink

--- a/app/routes/_dashboard.tsx
+++ b/app/routes/_dashboard.tsx
@@ -38,9 +38,11 @@ export default function Dashboard() {
   const { numVideos, numBlogposts, numCourses, numLectures, numPodcasts } =
     useLoaderData<typeof loader>();
 
+  const { pathname } = useLocation();
+
   return (
     <div className="w-full sm:mt-16">
-      {useLocation().pathname === "/" && (
+      {pathname === "/" && (
         <section className="text-left text-white">
           <p className="font-serif text-xl">En variants</p>
           <h2>Læringshub</h2>

--- a/app/routes/_dashboard_.tags.tsx
+++ b/app/routes/_dashboard_.tags.tsx
@@ -3,16 +3,6 @@ import ErrorComponent from "~/components/Error";
 
 const Tags = () => (
   <div className="mt-24 block w-full text-left">
-    <section className="text-left text-white">
-      <p className="font-serif text-xl">En variant av en</p>
-      <h2>Læringshub</h2>
-      <p className="mt-8">
-        Vi i Variant lager og holder en del kurs og foredrag i flere
-        sammenhenger. <br /> Vi har noen bloggposter her, noen YouTube-videoer
-        der, og noen foredrag en annen plass. <br />
-        Dette har vi samlet i denne læringshuben.
-      </p>
-    </section>
     {/* Todo: Add functionality for searching for tags here */}
     <div className="my-8">
       <Outlet />


### PR DESCRIPTION
Closes #128 

Ikke vis header og tekst på alle sidene. Også fjernet fra tags-siden.

![bilde](https://github.com/varianter/joy/assets/10518767/ca2ed661-a104-4a5b-a97d-a84811ceec85)

Minuset er at navigasjonen nå "hopper" opp
