### PR TITLE
Feat/113 remove truncate and fix heading size

### DIFF
--- a/app/components/ArticlePreview.tsx
+++ b/app/components/ArticlePreview.tsx
@@ -50,8 +50,8 @@ const ArticlePreview = (props: ArticlePreviewProps) => {
         <span className="font-sans">{category}</span>
         <span className="ml-auto font-sans">{createdDate}</span>
       </div>
-      <h3 className="text-left text-2xl line-clamp-2">{title}</h3>
-      <p className="my-5 line-clamp-3">{description}</p>
+      <h3 className="line-clamp-2">{title}</h3>
+      <p className="my-5 line-clamp-5">{description}</p>
       <div className="inset-x-6 flex flex-col items-center sm:absolute sm:bottom-2 md:flex-row md:justify-between">
         <span className="hidden sm:flex md:order-1">
           <Link to={linkButtonText().route}>{linkButtonText().text}</Link>

--- a/app/components/card/CardWithContent.tsx
+++ b/app/components/card/CardWithContent.tsx
@@ -37,9 +37,9 @@ const CardWithContent = ({ buttonText, content }: CardWithContentProps) => {
             id={content.id}
           />
         </div>
-        <div className="bottom-0 overflow-hidden py-3 sm:p-3">
-          <h3 className="text-left text-2xl line-clamp-1">{content.title}</h3>
-          <p className="my-5 text-base line-clamp-3">{content.description}</p>
+        <div className="overflow-hidden p-3">
+          <h3 className="line-clamp-2">{content.title}</h3>
+          <p className="my-5 line-clamp-5">{content.description}</p>
         </div>
         <div className="w-full items-center sm:flex sm:px-3 sm:pb-6">
           <span className="hidden font-sans sm:flex">

--- a/app/components/layout/Layout.tsx
+++ b/app/components/layout/Layout.tsx
@@ -42,9 +42,6 @@ export const Layout = ({
           <NavLink className="w-32" to="/">
             <img alt={"Variant-logo"} src={"/assets/variant-bw.svg"} />
           </NavLink>
-          <h1 className="hidden text-white md:ml-6 md:mt-2 md:block md:text-4xl">
-            Læreglede
-          </h1>
         </div>
 
         <div className="my-4 w-full lg:px-48">

--- a/app/routes/_dashboard.tsx
+++ b/app/routes/_dashboard.tsx
@@ -40,8 +40,8 @@ export default function Dashboard() {
   return (
     <div className="w-full sm:mt-16">
       <section className="text-left text-white">
-        <p className="font-serif text-xl">En variants</p>
-        <h2>Læringshub</h2>
+        <p className="font-serif text-lg">En variants</p>
+        <h1>Læringshub</h1>
         <p className="mt-8">
           I Variant er læreglede en av våre{" "}
           <a

--- a/app/styles/shared.css
+++ b/app/styles/shared.css
@@ -24,44 +24,38 @@
 }
 
 h1 {
-  font-size: 5.05rem;
+  font-size: 2rem;
   font-family: "Recoleta-Regular";
   line-height: 1.2;
 }
 
 h2 {
-  font-size: 3.4rem;
+  font-size: 1.5rem;
   font-family: "Recoleta-Regular";
-  line-height: 1.2;
 }
 
 h3 {
-  font-size: 2.25rem;
+  font-size: 1.17rem;
   font-family: "Recoleta-Regular";
-  line-height: 1.2;
   text-align: left;
 }
 
 h4,
 .heading-4 {
-  font-size: 1.5rem;
+  font-size: 1rem;
   font-family: "Recoleta-Regular";
-  line-height: 1.3;
   text-align: left;
 }
 
 p,
 li {
-  font-size: 1rem;
+  font-size: 0.8rem;
   font-family: "Graphic-Regular";
-  line-height: 1.6;
   text-align: left;
 }
 
 a {
-  font-size: 1rem;
   font-family: "Graphic-Regular";
-  line-height: 1.6;
   text-decoration: underline;
   transition: border-bottom 200ms ease-out;
 }


### PR DESCRIPTION
Endrer til å vise to linjer for tittel og fem for beskrivelse. Redefinerer også størrelse på overskrifter ihht web-standard, og fjerner `læreglede` fra logoen

Closing #113 

<img width="350" alt="Skjermbilde 2023-05-12 kl  10 11 54" src="https://github.com/varianter/joy/assets/6595982/76dfb6e9-08f1-4de3-9308-76d79b2405e7"><img width="350" alt="Skjermbilde 2023-05-12 kl  10 12 32" src="https://github.com/varianter/joy/assets/6595982/d457beff-b2af-4c58-97fa-f90ad07db582"><img width="350" alt="Skjermbilde 2023-05-12 kl  10 13 54" src="https://github.com/varianter/joy/assets/6595982/53d9e84e-60d0-40ce-ab93-a27044ed4a94"><img width="350" alt="Skjermbilde 2023-05-12 kl  10 14 00" src="https://github.com/varianter/joy/assets/6595982/d44a3350-8111-4f4a-9b03-7b49bdb3673e">

